### PR TITLE
compatibility with coffeescript 1.7.1

### DIFF
--- a/libs/modules/server/index.coffee
+++ b/libs/modules/server/index.coffee
@@ -48,7 +48,7 @@ launchServer = (gConfig)->
 	# Fork process to create and start localServer
 	pChild = childProcess.fork(
 		path.join(__dirname, "./dispatcher.js"),
-		null, {
+		[], {
 			silent: true,
 			stdio: [process.stdin, process.stdout]
 		})


### PR DESCRIPTION
修复 coffeescript 兼容性问题, coffeescript  ~ <= 1.7.1  验证通过

child_process.fork 返回的对象 pChild 的 stdin, stdout, stderr 值均为 null.

错误信息如下:

```
E:\code\fedproj>fed server -w ./configs/index.json
TypeError: Cannot call method 'on' of null
  at launchServer (C:\Users\bitdewy\AppData\Roaming\npm\node_modules\fed\libs\m
odules\server\index.coffee:57:16)
  at exports.exec (C:\Users\bitdewy\AppData\Roaming\npm\node_modules\fed\libs\m
odules\server\index.coffee:23:2)
  at Object.<anonymous> (C:\Users\bitdewy\AppData\Roaming\npm\node_modules\fed\
fed.coffee:41:9)
  at Object.<anonymous> (C:\Users\bitdewy\AppData\Roaming\npm\node_modules\fed\
fed.coffee:4:1)
  at Module._compile (module.js:456:26)

E:\code\fedproj>
```
